### PR TITLE
feat: add claimed and supply tokens to the metadata

### DIFF
--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -214,6 +214,29 @@ impl Faucet {
     pub fn faucet_id(&self) -> FaucetId {
         self.id
     }
+
+    /// Returns the claimed supply of the faucet account.
+    ///
+    /// Retrieves the account record from the client's database and extracts the claimed supply
+    /// from its storage.
+    ///
+    /// # Panics
+    /// - If the client has not loaded the faucet account.
+    /// - If the faucet storage does not contain the claimed supply.
+    pub async fn get_claimed_supply(&self) -> Result<u64, ClientError> {
+        let account_record = self
+            .client
+            .get_account(self.id.account_id)
+            .await?
+            .expect("client should have loaded the faucet account");
+        let claimed_supply = account_record
+            .account()
+            .storage()
+            .get_item(0)
+            .expect("faucet storage should contain the claimed supply")[3]
+            .as_int();
+        Ok(claimed_supply)
+    }
 }
 
 // HELPER FUNCTIONS

--- a/bin/faucet/src/server/frontend.rs
+++ b/bin/faucet/src/server/frontend.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, atomic::AtomicU64};
+
 use axum::{
     Json,
     extract::State,
@@ -15,6 +17,8 @@ use crate::{faucet::FaucetId, types::AssetOptions};
 pub struct Metadata {
     pub id: FaucetId,
     pub asset_amount_options: AssetOptions,
+    pub claimed_supply: Arc<AtomicU64>,
+    pub max_supply: u64,
 }
 
 pub async fn get_index_html() -> Html<&'static str> {

--- a/bin/faucet/src/server/resources/index.css
+++ b/bin/faucet/src/server/resources/index.css
@@ -363,8 +363,8 @@ body {
 }
 
 .progress-bar {
-    width: 120px;
-    height: 3px;
+    width: 240px;
+    height: 4px;
     background-color: #e0e0e0;
     border-radius: 2px;
     margin-top: 4px;

--- a/bin/faucet/src/server/resources/index.js
+++ b/bin/faucet/src/server/resources/index.js
@@ -72,10 +72,11 @@ class MidenFaucet {
                     option.textContent = amount;
                     this.tokenSelect.appendChild(option);
                 }
-                // TODO: add metadata values
-                this.tokensClaimed.textContent = '0';
-                this.tokensSupply.textContent = '100,000,000,000';
-                this.progressFill.style.width = '0%';
+
+                this.tokensClaimed.textContent = data.claimed_supply.toLocaleString();
+                this.tokensSupply.textContent = data.max_supply.toLocaleString();
+                this.progressFill.style.width = (data.claimed_supply / data.max_supply) * 100 + '%';
+                // TODO: show error message if no more tokens available
             })
             .catch(error => {
                 console.error('Error fetching metadata:', error);


### PR DESCRIPTION
Closes https://github.com/0xMiden/miden-faucet/issues/21

This PR adds the `max_supply` and `claimed_supply` to the server metadata to show it in the frontend. 

To avoid blocking the client to get the claimed amounts on each metadata request, the server keeps a counter that is incremented on each successful minting request.