### PR TITLE
feat: add supply exceeded check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Redesigned the home frontend ([#20](https://github.com/0xMiden/miden-faucet/pull/20)).
 - Redesigned the tokens request flows ([#25](https://github.com/0xMiden/miden-faucet/pull/25)).
 - Added faucet supply amounts to the metadata ([#30](https://github.com/0xMiden/miden-faucet/pull/30)).
-- Added check supply exceeded check ([#31](https://github.com/0xMiden/miden-faucet/pull/31)). 
+- Added supply exceeded check ([#31](https://github.com/0xMiden/miden-faucet/pull/31)). 
 
 ## 0.10.0 (2025-07-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Redesigned the home frontend ([#20](https://github.com/0xMiden/miden-faucet/pull/20)).
 - Redesigned the tokens request flows ([#25](https://github.com/0xMiden/miden-faucet/pull/25)).
 - Added faucet supply amounts to the metadata ([#30](https://github.com/0xMiden/miden-faucet/pull/30)).
+- Added check supply exceeded check ([#31](https://github.com/0xMiden/miden-faucet/pull/31)). 
 
 ## 0.10.0 (2025-07-10)
 

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -255,7 +255,7 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
             let server = Server::new(
                 faucet.faucet_id(),
                 max_supply,
-                faucet.available_supply(),
+                faucet.claimed_supply(),
                 asset_options,
                 tx_mint_requests,
                 pow_secret.unwrap_or_default().as_str(),

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -232,7 +232,6 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
 
             let decimals = faucet_component.decimals();
             let max_supply = faucet_component.max_supply().as_int() / 10u64.pow(decimals.into());
-            let claimed_supply = faucet.get_claimed_supply().await? / 10u64.pow(decimals.into());
 
             let store =
                 Arc::new(SqliteStore::new(store_path).await.context("failed to create store")?);
@@ -256,7 +255,7 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
             let server = Server::new(
                 faucet.faucet_id(),
                 max_supply,
-                claimed_supply,
+                faucet.available_supply(),
                 asset_options,
                 tx_mint_requests,
                 pow_secret.unwrap_or_default().as_str(),

--- a/bin/faucet/src/server/get_tokens.rs
+++ b/bin/faucet/src/server/get_tokens.rs
@@ -63,7 +63,6 @@ pub async fn get_tokens(
         .map_err(|_| GetTokenError::FaucetReturnChannelClosed)?
         .map_err(GetTokenError::InvalidRequest)?;
 
-    server.increment_claimed_supply(requested_amount);
     Ok(Json(mint_response))
 }
 

--- a/bin/faucet/src/server/get_tokens.rs
+++ b/bin/faucet/src/server/get_tokens.rs
@@ -226,7 +226,7 @@ impl RawMintRequest {
         // requests can be included in the same batch and exceed the available supply.
         if !server.amount_is_available(asset_amount.inner()) {
             tracing::error!("faucet supply exceeded");
-            // return Err(MintRequestError::AvailableSupplyExceeded);
+            return Err(MintRequestError::AvailableSupplyExceeded);
         }
 
         Ok(MintRequest { account_id, note_type, asset_amount })

--- a/bin/faucet/src/server/mod.rs
+++ b/bin/faucet/src/server/mod.rs
@@ -190,6 +190,11 @@ impl Server {
     pub(crate) fn increment_claimed_supply(&self, amount: u64) {
         self.metadata.claimed_supply.fetch_add(amount, Ordering::Relaxed);
     }
+
+    /// Checks if the given amount is available to be claimed.
+    pub(crate) fn amount_is_available(&self, amount: u64) -> bool {
+        self.metadata.claimed_supply.load(Ordering::Relaxed) + amount <= self.metadata.max_supply
+    }
 }
 
 impl FromRef<Server> for &'static Metadata {

--- a/bin/faucet/src/server/mod.rs
+++ b/bin/faucet/src/server/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     sync::{
         Arc,
-        atomic::{AtomicU64, Ordering},
+        atomic::AtomicU64,
     },
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -64,7 +64,7 @@ impl Server {
     pub fn new(
         faucet_id: FaucetId,
         max_supply: u64,
-        available_supply: u64,
+        claimed_supply: Arc<AtomicU64>,
         asset_options: AssetOptions,
         mint_request_sender: MintRequestSender,
         pow_secret: &str,
@@ -76,7 +76,7 @@ impl Server {
         let metadata = Metadata {
             id: faucet_id,
             asset_amount_options: asset_options,
-            claimed_supply: Arc::new(AtomicU64::new(max_supply - available_supply)),
+            claimed_supply,
             max_supply,
         };
         // SAFETY: Leaking is okay because we want it to live as long as the application.
@@ -184,11 +184,6 @@ impl Server {
             .expect("current timestamp should be greater than unix epoch")
             .as_secs();
         self.pow.submit_challenge(account_id, api_key, challenge, nonce, timestamp)
-    }
-
-    /// Increments the claimed supply counter by the given amount.
-    pub(crate) fn increment_claimed_supply(&self, amount: u64) {
-        self.metadata.claimed_supply.fetch_add(amount, Ordering::Relaxed);
     }
 }
 

--- a/bin/faucet/src/server/mod.rs
+++ b/bin/faucet/src/server/mod.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::HashSet,
-    sync::{
-        Arc,
-        atomic::AtomicU64,
-    },
+    sync::{Arc, atomic::AtomicU64},
     time::{SystemTime, UNIX_EPOCH},
 };
 

--- a/bin/faucet/src/server/resources/index.js
+++ b/bin/faucet/src/server/resources/index.js
@@ -55,7 +55,6 @@ class MidenFaucet {
 
         try {
             await this.getTokens(powData.challenge, nonce, recipient, amount, isPrivateNote);
-            this.resetForm();
         } catch (error) {
             this.showError(`Failed to send tokens: ${error.message}`);
         }


### PR DESCRIPTION
closes https://github.com/0xMiden/miden-faucet/issues/23.

This PR adds a validation to check that the minting request amount does not exceed the available tokens to claim and the error is correctly showed in the frontend.

### Implementation details
This is done by adding an available supply counter on the faucet. During requests handling, the counter is decremented and the requests that exceed the available supply are filtered. 

A simpler alternative could be to just check for the execution error, but this would need to cancel the whole request batch even if only one request exceeds the limit.