### PR TITLE
chore: update `miden-client` to `f475d89f` and `mide-base` to `871ac9`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1716,9 +1716,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miden-air"
-version = "0.16.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e44193b6aa5a16b15f54c4f54f5bd1e9e834b15790e432bb27a3aafe4c61f"
+checksum = "f8f8a250a0d54c41e7ba9c7c3206c85de37ed891340b79c8f645b05cc4938c2d"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.16.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c58c646de70bcd72529da66398f046672fc7c4f62b603b44db3ed7303bbf732"
+checksum = "822b0c69f22346ddcaba307dbcb69d2e881fd4d074511da8f1b51c6d2a03d384"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#871ac9b61d5a61303a1b845470ee5c2e9009c5f9"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "miden-client"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-client?branch=tomyrd-downgrade-base#400647ee4a78b364d71f11e93f2f463243ad9268"
+source = "git+https://github.com/0xMiden/miden-client?branch=next#f475d89fd8121bebb41d64579efbe5f1db751546"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.16.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c82ad285bd63808a30210e155eb53ed599700d1c7b28a734907dd75d18f3d65"
+checksum = "f22a9b5fb8ef50eba125dba5ab15af1cefb801dc2ec02d54901166358ff3201c"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#871ac9b61d5a61303a1b845470ee5c2e9009c5f9"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.16.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8496bae26e51891f63f3448d7e4b3d406f0e81d48928dd0212d4d41dbd8ddfa"
+checksum = "01a16c81f550d17454769ffb51b3788cdf2f8cb56bf4b3bf7dc90957ba234dcc"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#de41f9c325f53f2457107294edadaba8c163cc01"
 dependencies = [
  "anyhow",
  "hex",
@@ -1982,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#d1cdc61d54775dac354e1e6307fc23418f64d2a9"
 dependencies = [
  "anyhow",
  "prost",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#de41f9c325f53f2457107294edadaba8c163cc01"
 dependencies = [
  "anyhow",
  "figment",
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#871ac9b61d5a61303a1b845470ee5c2e9009c5f9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2064,14 +2064,14 @@ dependencies = [
  "miden-debug-types",
  "miden-processor",
  "tracing",
- "winter-maybe-async 0.13.1",
+ "winter-maybe-async 0.13.0",
  "winter-prover",
 ]
 
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#d1cdc61d54775dac354e1e6307fc23418f64d2a9"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#871ac9b61d5a61303a1b845470ee5c2e9009c5f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2117,14 +2117,14 @@ dependencies = [
  "rand",
  "rand_chacha",
  "thiserror 2.0.12",
- "winter-maybe-async 0.13.1",
+ "winter-maybe-async 0.13.0",
  "winterfell",
 ]
 
 [[package]]
 name = "miden-tx"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#871ac9b61d5a61303a1b845470ee5c2e9009c5f9"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.16.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae1f8ff84ebaa13f8c97dc5b24ee0bf424e5d3b262cfa4f35608220a4f5e407"
+checksum = "af06bd6a4f215ce646b6ee57a481e1c083600e109d50d5e8fd782884acb0f07a"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2678,9 +2678,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2856,9 +2856,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags",
 ]
@@ -3005,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc_version"
@@ -3055,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
@@ -3617,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3629,9 +3629,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3703,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
  "indexmap",
  "serde",
@@ -4005,9 +4005,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.108"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e087ef3afcfc5301c6a67d03db4ffaaf70b2fc4b753d3b42558d8a5a7e770f43"
+checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4016,7 +4016,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.4",
+ "toml 0.9.2",
 ]
 
 [[package]]
@@ -4485,7 +4485,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -4521,11 +4521,10 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
- "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4694,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
+checksum = "473277f696e5359c00059118f3b4b26c1056591dfcf159175e4cd9f7f2f9aa13"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -4707,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
+checksum = "ef01ae983f420aee0943c3bd6a413df43a151c12d1851daf384e0a4c6e0563ec"
 dependencies = [
  "blake3",
  "sha3",
@@ -4719,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
+checksum = "10954644f1fcb79374801f458a66c9e5a3b771950e4816c5db36aaea8637422f"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -4730,9 +4729,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
+checksum = "147699a1350037b39c3fbbb993d944532e461fe3e46537ef7c36742ffc1a3498"
 dependencies = [
  "winter-utils",
 ]
@@ -4749,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
+checksum = "c3253cf551b6e481f6ebeee986e8a5eaa3fbe9e79b129824320765a6efe90cb8"
 dependencies = [
  "quote",
  "syn",
@@ -4759,24 +4758,24 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
+checksum = "4ee69201ecac6cf077571130ad5aa43f8a4c7de19b35245e1f00ba8294ffd18b"
 dependencies = [
  "tracing",
  "winter-air",
  "winter-crypto",
  "winter-fri",
  "winter-math",
- "winter-maybe-async 0.13.1",
+ "winter-maybe-async 0.13.0",
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-rand-utils"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
+checksum = "e4ff50bd9ffaf905154d96e967f863246378dd5600997db07575bd1e1fa22260"
 dependencies = [
  "rand",
  "winter-utils",
@@ -4784,18 +4783,18 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
+checksum = "2c14bedf485c77b8a6ce76b0afbd86038d12bf441c2ede64ea9e573e3ff9658f"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "winter-verifier"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
+checksum = "5a6ae1f01494541059a874286dbdb4ef52357ac28980fc4c4ebb2e6bda7fb718"
 dependencies = [
  "winter-air",
  "winter-crypto",
@@ -4806,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "winterfell"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f824ddd5aec8ca6a54307f20c115485a8a919ea94dd26d496d856ca6185f4f"
+checksum = "2a60be62bd793cae134656ab770236b471fee3a4c68b9c260a12c73ef294ca61"
 dependencies = [
  "winter-air",
  "winter-prover",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1716,9 +1716,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miden-air"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f8a250a0d54c41e7ba9c7c3206c85de37ed891340b79c8f645b05cc4938c2d"
+checksum = "cd7e44193b6aa5a16b15f54c4f54f5bd1e9e834b15790e432bb27a3aafe4c61f"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1728,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5453d77fc1a7e4642e1fd8855e1d5904087ac1ec53b02549a11af4697df2713"
+checksum = "257cca0c54d5a14eb607d144f4349b46af56e6ceef0b5e53a92ea2e61f3f1410"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822b0c69f22346ddcaba307dbcb69d2e881fd4d074511da8f1b51c6d2a03d384"
+checksum = "4c58c646de70bcd72529da66398f046672fc7c4f62b603b44db3ed7303bbf732"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "miden-client"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-client?branch=next#eb7643811a724378c63198b80c7d98a564777f0e"
+source = "git+https://github.com/0xMiden/miden-client?branch=tomyrd-downgrade-base#400647ee4a78b364d71f11e93f2f463243ad9268"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dee966d664e92903bd9d20e846179395c50941e608c975970c20c034a32ab64"
+checksum = "b7768911c8376a584743e070521023ff5107528f797eee76cc0614d48b4cae18"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.15.6"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f1065f4110c7f25f1f200ff12a742a321e4930f0585b5f4d6519cbc3601b43"
+checksum = "e4329275a11c7d8328b14a7129b21d40183056dcd0d871c3069be6e550d6ca40"
 dependencies = [
  "blake3",
  "cc",
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22a9b5fb8ef50eba125dba5ab15af1cefb801dc2ec02d54901166358ff3201c"
+checksum = "7c82ad285bd63808a30210e155eb53ed599700d1c7b28a734907dd75d18f3d65"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a16c81f550d17454769ffb51b3788cdf2f8cb56bf4b3bf7dc90957ba234dcc"
+checksum = "d8496bae26e51891f63f3448d7e4b3d406f0e81d48928dd0212d4d41dbd8ddfa"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#de41f9c325f53f2457107294edadaba8c163cc01"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
 dependencies = [
  "anyhow",
  "hex",
@@ -1982,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#de41f9c325f53f2457107294edadaba8c163cc01"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
 dependencies = [
  "anyhow",
  "prost",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#de41f9c325f53f2457107294edadaba8c163cc01"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
 dependencies = [
  "anyhow",
  "figment",
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fe7dd289f73562936b6810ed370d64e78129926c7f0f20860f8d263dfcb566"
+checksum = "8b3d8fb95de53071a391767549a5d6ef7113e121a33f9a63d91e6ae7b2ecfe6e"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2056,22 +2056,22 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ae8ccd743e679dccca400cb748eedc3d26c3ebd93a9ea6cb47ef50ed0555eb"
+checksum = "ffabff0a49ab0dbc7a8c7c1d8ea942cdc8744f20594e7ee28fd7bb36c2cad863"
 dependencies = [
  "miden-air",
  "miden-debug-types",
  "miden-processor",
  "tracing",
- "winter-maybe-async 0.13.0",
+ "winter-maybe-async 0.13.1",
  "winter-prover",
 ]
 
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#de41f9c325f53f2457107294edadaba8c163cc01"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#dc0b1202894c56bb3a1816d5f6ba4a11432522ac"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d090c8a83966282b5fcd96bc2c9c1b1f5f7569c6b85a086ff693b12213990"
+checksum = "bf434d1678ddffb9f2a5f40e00d2342d1a0ecb597f14373edee0ad60360f160f"
 dependencies = [
  "env_logger",
  "miden-assembly",
@@ -2104,10 +2104,11 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "anyhow",
  "async-trait",
+ "itertools",
  "miden-block-prover",
  "miden-lib",
  "miden-objects",
@@ -2116,14 +2117,14 @@ dependencies = [
  "rand",
  "rand_chacha",
  "thiserror 2.0.12",
- "winter-maybe-async 0.13.0",
+ "winter-maybe-async 0.13.1",
  "winterfell",
 ]
 
 [[package]]
 name = "miden-tx"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2138,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06bd6a4f215ce646b6ee57a481e1c083600e109d50d5e8fd782884acb0f07a"
+checksum = "4ae1f8ff84ebaa13f8c97dc5b24ee0bf424e5d3b262cfa4f35608220a4f5e407"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2151,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1771d84e358da9957786a7058b7431e2d5d5934e37de128b927b9e520ec0d2e"
+checksum = "4a53938d20b1f6efa94f60f475a64814d6913750aed021618a709812008d5bda"
 dependencies = [
  "lock_api",
  "loom",
@@ -2162,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253fb17aee78a1d9b0d2030fc1a14e7559590a43a7d2d00e7cce0bd23f61fbb6"
+checksum = "f409300fdd18a2da8581da1d38a5b7efc16e19ad267f48c4e74facad778d261e"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2677,9 +2678,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2855,9 +2856,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2913,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -3004,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"
@@ -3054,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -3470,7 +3471,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a43bddab41f8626c7bdaab872bbba75f8df5847b516d77c569c746e2ae5eb746"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3616,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3628,9 +3629,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3702,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
 dependencies = [
  "indexmap",
  "serde",
@@ -4004,9 +4005,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.106"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
+checksum = "e087ef3afcfc5301c6a67d03db4ffaaf70b2fc4b753d3b42558d8a5a7e770f43"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4015,7 +4016,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.2",
+ "toml 0.9.4",
 ]
 
 [[package]]
@@ -4484,7 +4485,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4520,10 +4521,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4692,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473277f696e5359c00059118f3b4b26c1056591dfcf159175e4cd9f7f2f9aa13"
+checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -4705,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01ae983f420aee0943c3bd6a413df43a151c12d1851daf384e0a4c6e0563ec"
+checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
 dependencies = [
  "blake3",
  "sha3",
@@ -4717,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10954644f1fcb79374801f458a66c9e5a3b771950e4816c5db36aaea8637422f"
+checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -4728,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147699a1350037b39c3fbbb993d944532e461fe3e46537ef7c36742ffc1a3498"
+checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
 dependencies = [
  "winter-utils",
 ]
@@ -4747,9 +4749,9 @@ dependencies = [
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3253cf551b6e481f6ebeee986e8a5eaa3fbe9e79b129824320765a6efe90cb8"
+checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
 dependencies = [
  "quote",
  "syn",
@@ -4757,24 +4759,24 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee69201ecac6cf077571130ad5aa43f8a4c7de19b35245e1f00ba8294ffd18b"
+checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
 dependencies = [
  "tracing",
  "winter-air",
  "winter-crypto",
  "winter-fri",
  "winter-math",
- "winter-maybe-async 0.13.0",
+ "winter-maybe-async 0.13.1",
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-rand-utils"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ff50bd9ffaf905154d96e967f863246378dd5600997db07575bd1e1fa22260"
+checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
 dependencies = [
  "rand",
  "winter-utils",
@@ -4782,18 +4784,18 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c14bedf485c77b8a6ce76b0afbd86038d12bf441c2ede64ea9e573e3ff9658f"
+checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "winter-verifier"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6ae1f01494541059a874286dbdb4ef52357ac28980fc4c4ebb2e6bda7fb718"
+checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
 dependencies = [
  "winter-air",
  "winter-crypto",
@@ -4804,9 +4806,9 @@ dependencies = [
 
 [[package]]
 name = "winterfell"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60be62bd793cae134656ab770236b471fee3a4c68b9c260a12c73ef294ca61"
+checksum = "43f824ddd5aec8ca6a54307f20c115485a8a919ea94dd26d496d856ca6185f4f"
 dependencies = [
  "winter-air",
  "winter-prover",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opt-level = 2
 
 [workspace.dependencies]
 # miden-client dependencies.
-miden-client = { branch = "tomyrd-downgrade-base", git = "https://github.com/0xMiden/miden-client" }
+miden-client = { branch = "next", git = "https://github.com/0xMiden/miden-client" }
 
 # miden-node dependencies.
 miden-node-utils = { branch = "next", git = "https://github.com/0xMiden/miden-node" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opt-level = 2
 
 [workspace.dependencies]
 # miden-client dependencies.
-miden-client = { branch = "next", git = "https://github.com/0xMiden/miden-client" }
+miden-client = { branch = "tomyrd-downgrade-base", git = "https://github.com/0xMiden/miden-client" }
 
 # miden-node dependencies.
 miden-node-utils = { branch = "next", git = "https://github.com/0xMiden/miden-node" }

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -59,7 +59,7 @@ impl Serialize for FaucetId {
 pub struct Faucet {
     id: FaucetId,
     decimals: u8,
-    client: Client,
+    client: Client<FilesystemKeyStore<StdRng>>,
     tx_prover: Arc<dyn TransactionProver>,
 }
 

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -15,7 +15,7 @@ use miden_client::{
     Felt,
     account::{
         AccountBuilder, AccountFile, AccountStorageMode, AccountType,
-        component::{BasicFungibleFaucet, RpoFalcon512},
+        component::{AuthRpoFalcon512, BasicFungibleFaucet},
     },
     asset::TokenSymbol,
     auth::AuthSecretKey,
@@ -227,7 +227,8 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
                 timeout,
                 remote_tx_prover_url,
             )
-            .await?;
+            .await
+            .context("failed to load faucet")?;
             let store =
                 Arc::new(SqliteStore::new(store_path).await.context("failed to create store")?);
 
@@ -306,7 +307,7 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
                 .account_type(AccountType::FungibleFaucet)
                 .storage_mode(AccountStorageMode::Public)
                 .with_component(BasicFungibleFaucet::new(symbol, decimals, max_supply)?)
-                .with_auth_component(RpoFalcon512::new(secret.public_key()))
+                .with_auth_component(AuthRpoFalcon512::new(secret.public_key()))
                 .build()
                 .context("failed to create basic fungible faucet account")?;
 

--- a/bin/faucet/src/testing/stub_rpc_api.rs
+++ b/bin/faucet/src/testing/stub_rpc_api.rs
@@ -1,20 +1,5 @@
 use anyhow::Context;
-use miden_node_proto::generated::{
-    block::BlockHeader,
-    requests::{
-        CheckNullifiersByPrefixRequest, CheckNullifiersRequest, GetAccountDetailsRequest,
-        GetAccountProofsRequest, GetAccountStateDeltaRequest, GetBlockByNumberRequest,
-        GetBlockHeaderByNumberRequest, GetNotesByIdRequest, SubmitProvenTransactionRequest,
-        SyncNoteRequest, SyncStateRequest,
-    },
-    responses::{
-        CheckNullifiersByPrefixResponse, CheckNullifiersResponse, GetAccountDetailsResponse,
-        GetAccountProofsResponse, GetAccountStateDeltaResponse, GetBlockByNumberResponse,
-        GetBlockHeaderByNumberResponse, GetNotesByIdResponse, RpcStatusResponse,
-        SubmitProvenTransactionResponse, SyncNoteResponse, SyncStateResponse,
-    },
-    rpc::api_server,
-};
+use miden_node_proto::generated::{self as proto, rpc::api_server};
 use miden_testing::MockChain;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -29,27 +14,28 @@ pub struct StubRpcApi;
 impl api_server::Api for StubRpcApi {
     async fn check_nullifiers(
         &self,
-        _request: Request<CheckNullifiersRequest>,
-    ) -> Result<Response<CheckNullifiersResponse>, Status> {
+        _request: Request<proto::rpc_store::NullifierList>,
+    ) -> Result<Response<proto::rpc_store::CheckNullifiersResponse>, Status> {
         unimplemented!();
     }
 
     async fn check_nullifiers_by_prefix(
         &self,
-        _request: Request<CheckNullifiersByPrefixRequest>,
-    ) -> Result<Response<CheckNullifiersByPrefixResponse>, Status> {
+        _request: Request<proto::rpc_store::CheckNullifiersByPrefixRequest>,
+    ) -> Result<Response<proto::rpc_store::CheckNullifiersByPrefixResponse>, Status> {
         unimplemented!();
     }
 
     async fn get_block_header_by_number(
         &self,
-        _request: Request<GetBlockHeaderByNumberRequest>,
-    ) -> Result<Response<GetBlockHeaderByNumberResponse>, Status> {
+        _request: Request<proto::shared::BlockHeaderByNumberRequest>,
+    ) -> Result<Response<proto::shared::BlockHeaderByNumberResponse>, Status> {
         let mock_chain = MockChain::new();
 
-        let block_header = BlockHeader::from(mock_chain.latest_block_header()).into();
+        let block_header =
+            proto::blockchain::BlockHeader::from(mock_chain.latest_block_header()).into();
 
-        Ok(Response::new(GetBlockHeaderByNumberResponse {
+        Ok(Response::new(proto::shared::BlockHeaderByNumberResponse {
             block_header,
             mmr_path: None,
             chain_length: None,
@@ -58,9 +44,9 @@ impl api_server::Api for StubRpcApi {
 
     async fn sync_state(
         &self,
-        _request: Request<SyncStateRequest>,
-    ) -> Result<Response<SyncStateResponse>, Status> {
-        Ok(Response::new(SyncStateResponse {
+        _request: Request<proto::rpc_store::SyncStateRequest>,
+    ) -> Result<Response<proto::rpc_store::SyncStateResponse>, Status> {
+        Ok(Response::new(proto::rpc_store::SyncStateResponse {
             chain_tip: 0,
             block_header: None,
             mmr_delta: None,
@@ -72,54 +58,59 @@ impl api_server::Api for StubRpcApi {
 
     async fn sync_notes(
         &self,
-        _request: Request<SyncNoteRequest>,
-    ) -> Result<Response<SyncNoteResponse>, Status> {
+        _request: Request<proto::rpc_store::SyncNotesRequest>,
+    ) -> Result<Response<proto::rpc_store::SyncNotesResponse>, Status> {
         unimplemented!();
     }
 
     async fn get_notes_by_id(
         &self,
-        _request: Request<GetNotesByIdRequest>,
-    ) -> Result<Response<GetNotesByIdResponse>, Status> {
+        _request: Request<proto::note::NoteIdList>,
+    ) -> Result<Response<proto::note::CommittedNoteList>, Status> {
         unimplemented!();
     }
 
     async fn submit_proven_transaction(
         &self,
-        _request: Request<SubmitProvenTransactionRequest>,
-    ) -> Result<Response<SubmitProvenTransactionResponse>, Status> {
-        Ok(Response::new(SubmitProvenTransactionResponse { block_height: 0 }))
+        _request: Request<proto::transaction::ProvenTransaction>,
+    ) -> Result<Response<proto::block_producer::SubmitProvenTransactionResponse>, Status> {
+        Ok(Response::new(proto::block_producer::SubmitProvenTransactionResponse {
+            block_height: 0,
+        }))
     }
 
     async fn get_account_details(
         &self,
-        _request: Request<GetAccountDetailsRequest>,
-    ) -> Result<Response<GetAccountDetailsResponse>, Status> {
+        _request: Request<proto::account::AccountId>,
+    ) -> Result<Response<proto::account::AccountDetails>, Status> {
         Err(Status::not_found("account not found"))
     }
 
     async fn get_block_by_number(
         &self,
-        _request: Request<GetBlockByNumberRequest>,
-    ) -> Result<Response<GetBlockByNumberResponse>, Status> {
+        _request: Request<proto::blockchain::BlockNumber>,
+    ) -> Result<Response<proto::blockchain::MaybeBlock>, Status> {
         unimplemented!()
     }
 
     async fn get_account_state_delta(
         &self,
-        _request: Request<GetAccountStateDeltaRequest>,
-    ) -> Result<Response<GetAccountStateDeltaResponse>, Status> {
+        _request: Request<proto::rpc_store::AccountStateDeltaRequest>,
+    ) -> Result<Response<proto::rpc_store::AccountStateDelta>, Status> {
         unimplemented!()
     }
 
     async fn get_account_proofs(
         &self,
-        _request: Request<GetAccountProofsRequest>,
-    ) -> Result<Response<GetAccountProofsResponse>, Status> {
+        _request: Request<proto::rpc_store::AccountProofsRequest>,
+    ) -> Result<Response<proto::rpc_store::AccountProofs>, Status> {
         unimplemented!()
     }
 
-    async fn status(&self, _request: Request<()>) -> Result<Response<RpcStatusResponse>, Status> {
+    async fn status(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<proto::rpc::RpcStatus>, Status> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
some other dependencies like miden-crypto were also updated

instead of downgrading https://github.com/0xMiden/miden-client/pull/1105, we should now have all versions matching

closes https://github.com/0xMiden/miden-faucet/pull/33