### PR TITLE
revert: use axum `ServeDir` for frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Changes
 
-- Introduced `miden-faucet-lib` crate ([#10](https://github.com/0xMiden/miden-faucet/pull/10)).
 - Integrated miden-client ([#11](https://github.com/0xMiden/miden-faucet/pull/11)).
 - Added `/get_note` endpoint ([#19](https://github.com/0xMiden/miden-faucet/pull/19)).
 - Redesigned the home frontend ([#20](https://github.com/0xMiden/miden-faucet/pull/20)).
 - Redesigned the tokens request flows ([#25](https://github.com/0xMiden/miden-faucet/pull/25)).
 - Added faucet supply amounts to the metadata ([#30](https://github.com/0xMiden/miden-faucet/pull/30)).
 - Added supply exceeded check ([#31](https://github.com/0xMiden/miden-faucet/pull/31)). 
-- Use HTTP 429 status code for rate limited error ([#51](https://github.com/0xMiden/miden-faucet/pull/51)).
+- Introduced `miden-faucet-client` crate ([#10](https://github.com/0xMiden/miden-faucet/pull/10)).
 - Replace amount options validation for maximum claimable amount ([#52](https://github.com/0xMiden/miden-faucet/pull/52)).
+- Use HTTP 429 status code for rate limited error ([#51](https://github.com/0xMiden/miden-faucet/pull/51)).
 
 ## 0.10.0 (2025-07-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Changes
 
+- Introduced `miden-faucet-lib` crate ([#10](https://github.com/0xMiden/miden-faucet/pull/10)).
 - Integrated miden-client ([#11](https://github.com/0xMiden/miden-faucet/pull/11)).
 - Added `/get_note` endpoint ([#19](https://github.com/0xMiden/miden-faucet/pull/19)).
 - Redesigned the home frontend ([#20](https://github.com/0xMiden/miden-faucet/pull/20)).
 - Redesigned the tokens request flows ([#25](https://github.com/0xMiden/miden-faucet/pull/25)).
 - Added faucet supply amounts to the metadata ([#30](https://github.com/0xMiden/miden-faucet/pull/30)).
 - Added supply exceeded check ([#31](https://github.com/0xMiden/miden-faucet/pull/31)). 
-- Introduced `miden-faucet-client` crate ([#10](https://github.com/0xMiden/miden-faucet/pull/10)).
-- Replace amount options validation for maximum claimable amount ([#52](https://github.com/0xMiden/miden-faucet/pull/52)).
 - Use HTTP 429 status code for rate limited error ([#51](https://github.com/0xMiden/miden-faucet/pull/51)).
+- Replace amount options validation for maximum claimable amount ([#52](https://github.com/0xMiden/miden-faucet/pull/52)).
 
 ## 0.10.0 (2025-07-10)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,12 +1004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1775,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-extra",
  "base64",
  "clap",
  "fantoccini",
@@ -2136,16 +2153,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -3845,20 +3852,11 @@ checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
  "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4006,12 +4004,6 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -24,6 +24,7 @@ miden-client = { features = ["sqlite", "tonic"], workspace = true }
 anyhow                = { workspace = true }
 async-trait           = { version = "0.1" }
 axum                  = { features = ["tokio"], version = "0.8" }
+axum-extra            = { version = "0.10" }
 base64                = { version = "0.22" }
 clap                  = { features = ["derive", "env", "string"], version = "4.5" }
 http                  = { workspace = true }
@@ -41,7 +42,7 @@ tokio                 = { features = ["fs"], workspace = true }
 tokio-stream          = { features = ["net"], workspace = true }
 tonic                 = { features = ["tls-native-roots"], workspace = true }
 tower                 = { workspace = true }
-tower-http            = { features = ["cors", "fs", "set-header", "trace"], workspace = true }
+tower-http            = { features = ["cors", "set-header", "trace"], workspace = true }
 tracing               = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber    = { workspace = true }

--- a/bin/faucet/src/api/frontend.rs
+++ b/bin/faucet/src/api/frontend.rs
@@ -1,0 +1,35 @@
+use axum::response::{Html, IntoResponse, Response};
+use axum_extra::response::{Css, JavaScript};
+use http::header::{self};
+
+pub async fn get_index_html() -> Html<&'static str> {
+    Html(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend/index.html")))
+}
+
+pub async fn get_not_found_html() -> Html<&'static str> {
+    Html(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend/not_found.html")))
+}
+
+pub async fn get_index_js() -> JavaScript<&'static str> {
+    JavaScript(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend/index.js")))
+}
+
+pub async fn get_index_css() -> Css<&'static str> {
+    Css(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend/index.css")))
+}
+
+pub async fn get_background() -> Response {
+    (
+        [(header::CONTENT_TYPE, header::HeaderValue::from_static("image/png"))],
+        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend/background.png"),),
+    )
+        .into_response()
+}
+
+pub async fn get_favicon() -> Response {
+    (
+        [(header::CONTENT_TYPE, header::HeaderValue::from_static("image/x-icon"))],
+        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/frontend/favicon.ico"),),
+    )
+        .into_response()
+}

--- a/bin/faucet/src/api/frontend.rs
+++ b/bin/faucet/src/api/frontend.rs
@@ -1,3 +1,6 @@
+//! This file explicitly embeds each of the frontend files into the binary using `include_str!` and
+//! `include_bytes!`.
+
 use axum::response::{Html, IntoResponse, Response};
 use axum_extra::response::{Css, JavaScript};
 use http::header::{self};

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -348,7 +348,7 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
 mod test {
     use std::env::temp_dir;
     use std::num::NonZeroUsize;
-    use std::path::PathBuf;
+    
     use std::process::Stdio;
     use std::str::FromStr;
     use std::time::{Duration, Instant};
@@ -479,7 +479,7 @@ mod test {
                         faucet_account_path: faucet_account_path.clone(),
                         remote_tx_prover_url: None,
                         open_telemetry: false,
-                        store_path: PathBuf::from(temp_dir().join("test_store.sqlite3")),
+                        store_path: temp_dir().join("test_store.sqlite3"),
                     },
                 }))
                 .await

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -348,7 +348,6 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
 mod test {
     use std::env::temp_dir;
     use std::num::NonZeroUsize;
-    
     use std::process::Stdio;
     use std::str::FromStr;
     use std::time::{Duration, Instant};


### PR DESCRIPTION
Addresses https://github.com/0xMiden/miden-faucet/issues/59

This PR reverts the changes made on https://github.com/0xMiden/miden-faucet/pull/54. Referencing the frontend as `concat!(env!("CARGO_MANIFEST_DIR"), "/frontend");` was causing problems when the faucet is installed as a Debian package. This PR changes it to embed the static files on the binary,.