### PR TITLE
feat: update default `--max-claimable-amount`

### DIFF
--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -92,7 +92,7 @@ pub enum Command {
         faucet_account_path: PathBuf,
 
         /// The maximum amount of assets base units that can be dispersed on each request.
-        #[arg(long = "max-claimable-amount", value_name = "U64", env = ENV_MAX_CLAIMABLE_AMOUNT, default_value = "1000")]
+        #[arg(long = "max-claimable-amount", value_name = "U64", env = ENV_MAX_CLAIMABLE_AMOUNT, default_value = "1000000000")]
         max_claimable_amount: u64,
 
         /// Endpoint of the remote transaction prover in the format `<protocol>://<host>[:<port>]`.


### PR DESCRIPTION
Context: https://github.com/0xMiden/miden-faucet/issues/62

This PR sets the default value for `--max-claimable-amount` at 1000000000. This is 1000 tokens when using 6 decimals, the value used for the testnet faucet.