### PR TITLE
feat: show explorer button only when available

### DIFF
--- a/bin/faucet/frontend/index.js
+++ b/bin/faucet/frontend/index.js
@@ -237,9 +237,10 @@ class MidenFaucet {
 
             const explorerButton = document.getElementById('explorer-button');
             if (mintingData.explorer_url) {
-                explorerButton.onclick = () => window.open(mintingData.explorer_url + '/tx/' + mintingData.transaction_id, '_blank');
+                explorerButton.style.display = 'block';
+                explorerButton.onclick = () => window.open(mintingData.explorer_url + '/tx/' + mintingData.tx_id, '_blank');
             } else {
-                explorerButton.onclick = () => this.showPublicModalError('Explorer URL not available');
+                explorerButton.style.display = 'none';
             }
 
             completedPublicModal.onclick = (e) => {


### PR DESCRIPTION
This PR changes the frontend to show the explorer button only when available, i.e. only on testnet.

Context: https://github.com/0xMiden/miden-faucet/issues/65