### PR TITLE
feat: bring back network arg

### DIFF
--- a/bin/faucet/README.md
+++ b/bin/faucet/README.md
@@ -26,11 +26,11 @@ miden-faucet create-faucet-account \
 miden-faucet start \
   --endpoint http://localhost:8080 \
   --node-url https://rpc.testnet.miden.io:443 \
+  --network testnet \
   --account <path to faucet.mac>
 ```
 
 After a few seconds you may go to `http://localhost:8080` and see the faucet UI.
-
 
 ## Faucet security features:
 The faucet implements several security measures to prevent abuse:

--- a/bin/faucet/src/network.rs
+++ b/bin/faucet/src/network.rs
@@ -1,0 +1,43 @@
+use std::convert::Infallible;
+use std::str::FromStr;
+
+use miden_client::account::{NetworkId, NetworkIdError};
+use serde::{Deserialize, Serialize};
+
+// NETWORK
+// ================================================================================================
+
+/// Represents the network where the faucet is running. It is used to show the correct bech32
+/// addresses and explorer URL in the UI.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum FaucetNetwork {
+    Testnet,
+    Devnet,
+    Localhost,
+    Custom(String),
+}
+
+impl FromStr for FaucetNetwork {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Infallible> {
+        match s.to_lowercase().as_str() {
+            "devnet" => Ok(FaucetNetwork::Devnet),
+            "localhost" => Ok(FaucetNetwork::Localhost),
+            "testnet" => Ok(FaucetNetwork::Testnet),
+            custom => Ok(FaucetNetwork::Custom(custom.to_string())),
+        }
+    }
+}
+
+impl FaucetNetwork {
+    /// Converts the network configuration to a network ID.
+    pub fn to_network_id(&self) -> Result<NetworkId, NetworkIdError> {
+        Ok(match self {
+            FaucetNetwork::Testnet => NetworkId::Testnet,
+            FaucetNetwork::Devnet => NetworkId::Devnet,
+            FaucetNetwork::Localhost => NetworkId::new("mlcl")?,
+            FaucetNetwork::Custom(s) => NetworkId::new(s)?,
+        })
+    }
+}

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -84,6 +84,7 @@ impl Faucet {
     #[instrument(name = "faucet.load", fields(id), skip_all)]
     pub async fn load(
         store_path: PathBuf,
+        network_id: NetworkId,
         account_file: AccountFile,
         node_url: &Url,
         timeout: Duration,
@@ -152,7 +153,7 @@ impl Faucet {
             Some(url) => Arc::new(RemoteTransactionProver::new(url)),
             None => Arc::new(LocalTransactionProver::default()),
         };
-        let id = FaucetId::new(account.id(), endpoint.to_network_id());
+        let id = FaucetId::new(account.id(), network_id);
         let max_supply = AssetAmount::new(faucet.max_supply().as_int())?;
         let issuance = Arc::new(RwLock::new(AssetAmount::new(issuance.as_int())?));
 


### PR DESCRIPTION
Brings back network param, removed in https://github.com/0xMiden/miden-faucet/pull/63. 
The only difference is that in the referenced PR, we used to infer the explorer URL based on the network, but I did not bring that back and instead chose to keep it as a config.