### PR TITLE
fix: display minted token amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.3 (2025-09-08)
+## 0.11.3 (2025-09-09)
 
 - Fixed display for minted token amount ([#82](https://github.com/0xMiden/miden-faucet/pull/82)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.3 (2025-09-08)
+
+- Fixed display for minted token amount ([#82](https://github.com/0xMiden/miden-faucet/pull/82)).
+
 ## 0.11.2 (2025-09-08)
 
 - Refreshed dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet-lib"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "miden-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-faucet"
 rust-version = "1.88"
-version      = "0.11.2"
+version      = "0.11.3"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/bin/faucet/frontend/index.js
+++ b/bin/faucet/frontend/index.js
@@ -25,7 +25,7 @@ class MidenFaucet {
     async handleSendTokens(isPrivateNote) {
         const recipient = this.recipientInput.value.trim();
         const amount = this.tokenSelect.value;
-        const amountAsTokens = this.tokenSelect.textContent[this.tokenSelect.selectedIndex];
+        const amountAsTokens = this.tokenSelect[this.tokenSelect.selectedIndex].textContent;
 
         if (!recipient) {
             this.showError('Recipient address is required.');


### PR DESCRIPTION
Currently there is a bug on the frontend that causes the minted amount to show as 0:
<img width="1248" height="614" alt="image" src="https://github.com/user-attachments/assets/7a847909-520e-4b53-ad49-895124df8748" />

The problem is on how we index the selected option in the frontend.