### PR TITLE
Fix faucet issue 91

### DIFF
--- a/bin/faucet/src/api/get_metadata.rs
+++ b/bin/faucet/src/api/get_metadata.rs
@@ -7,6 +7,8 @@ use miden_faucet_lib::FaucetId;
 use miden_faucet_lib::types::AssetAmount;
 use serde::{Serialize, Serializer};
 use url::Url;
+use tracing::instrument;
+use crate::COMPONENT;
 
 /// Describes the faucet metadata needed to show on the frontend.
 pub struct Metadata {
@@ -36,6 +38,7 @@ impl Serialize for Metadata {
 // ENDPOINT
 // ================================================================================================
 
+#[instrument(parent = None, target = COMPONENT, name = "faucet.server.get_metadata", skip_all)]
 pub async fn get_metadata(State(metadata): State<&'static Metadata>) -> Json<&'static Metadata> {
     Json(metadata)
 }

--- a/bin/faucet/src/api/get_pow.rs
+++ b/bin/faucet/src/api/get_pow.rs
@@ -2,17 +2,23 @@ use axum::Json;
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
 use http::StatusCode;
+use tracing::instrument;
 use miden_client::account::{AccountId, Address};
 use miden_pow_rate_limiter::{Challenge, PoWRateLimiter};
 use serde::Deserialize;
 
 use crate::api::AccountError;
+use crate::COMPONENT;
 use crate::api_key::ApiKey;
 use crate::error_report::ErrorReport;
 
 // ENDPOINT
 // ================================================================================================
 
+#[instrument(
+    parent = None, target = COMPONENT, name = "faucet.server.get_pow", skip_all,
+    fields(account_id = %params.account_id)
+)]
 pub async fn get_pow(
     State(rate_limiter): State<PoWRateLimiter>,
     Query(params): Query<RawPowRequest>,

--- a/bin/faucet/src/api/get_tokens.rs
+++ b/bin/faucet/src/api/get_tokens.rs
@@ -41,19 +41,27 @@ pub async fn get_tokens(
     span.record("amount", requested_amount);
     span.record("note_type", validated_request.note_type.to_string());
 
-    server
-        .mint_state
-        .request_sender
-        .try_send((validated_request, mint_response_sender))
-        .map_err(|err| match err {
-            TrySendError::Full(_) => GetTokenError::FaucetOverloaded,
-            TrySendError::Closed(_) => GetTokenError::FaucetClosed,
-        })?;
+    {
+        let enqueue_span = tracing::info_span!(target: COMPONENT, "faucet.server.get_tokens.enqueue");
+        let _enter = enqueue_span.enter();
+        server
+            .mint_state
+            .request_sender
+            .try_send((validated_request, mint_response_sender))
+            .map_err(|err| match err {
+                TrySendError::Full(_) => GetTokenError::FaucetOverloaded,
+                TrySendError::Closed(_) => GetTokenError::FaucetClosed,
+            })?;
+    }
 
-    let mint_response = mint_response_receiver
-        .await
-        .map_err(|_| GetTokenError::FaucetReturnChannelClosed)?
-        .map_err(GetTokenError::MintError)?;
+    let mint_response = {
+        let await_span = tracing::info_span!(target: COMPONENT, "faucet.server.get_tokens.await_mint");
+        let _enter = await_span.enter();
+        mint_response_receiver
+            .await
+            .map_err(|_| GetTokenError::FaucetReturnChannelClosed)?
+            .map_err(GetTokenError::MintError)?
+    };
 
     Ok(Json(GetTokensResponse {
         tx_id: mint_response.tx_id.to_string(),

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -39,6 +39,11 @@ pub mod types;
 use crate::requests::{MintError, MintRequest, MintResponse, MintResponseSender};
 use crate::types::AssetAmount;
 
+// COMPONENT
+// ================================================================================================
+
+const COMPONENT: &str = "miden-faucet-client";
+
 const BATCH_SIZE: usize = 64;
 const TX_SCRIPT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/assets/tx_scripts/mint.txs"));
 
@@ -85,7 +90,7 @@ impl Faucet {
     ///
     /// If a remote transaction prover url is provided, it is used to prove transactions. Otherwise,
     /// a local transaction prover is used.
-    #[instrument(name = "faucet.load", fields(id), skip_all)]
+    #[instrument(target = COMPONENT, name = "faucet.load", fields(id), skip_all)]
     pub async fn load(
         store_path: PathBuf,
         network_id: NetworkId,
@@ -183,7 +188,7 @@ impl Faucet {
     ///
     /// Once the available supply is exceeded, any requests that exceed the supply will return an
     /// error. The request stream is closed and the minter shuts down.
-    #[instrument(name = "faucet.run", skip_all, err)]
+    #[instrument(target = COMPONENT, name = "faucet.run", skip_all, err)]
     pub async fn run(
         mut self,
         mut requests: Receiver<(MintRequest, MintResponseSender)>,
@@ -222,22 +227,60 @@ impl Faucet {
                 continue;
             }
 
-            let mut rng = {
+            // Root span for this mint attempt (batch)
+            let total_requested: u64 = valid_requests
+                .iter()
+                .map(|r| r.asset_amount.base_units())
+                .sum();
+            let num_private = valid_requests
+                .iter()
+                .filter(|r| matches!(r.note_type, crate::types::NoteType::Private))
+                .count() as u64;
+            let num_public = valid_requests.len() as u64 - num_private;
+            let mint_span = tracing::info_span!(
+                target: COMPONENT,
+                "faucet.mint",
+                faucet_id = %self.id.account_id,
+                num_requests = valid_requests.len() as u64,
+                total_requested = total_requested,
+                num_private = num_private,
+                num_public = num_public,
+                tx_id = tracing::field::Empty,
+            );
+            let _mint_enter = mint_span.enter();
+
+            // Build notes
+            let build_span = tracing::info_span!(
+                target: COMPONENT,
+                "faucet.mint.build_notes",
+                num_requests = valid_requests.len() as u64
+            );
+            let notes = {
+                let _enter = build_span.enter();
+                let mut rng = {
                 let auth_seed: [u64; 4] = rng().random();
                 let rng_seed = Word::from(auth_seed.map(Felt::new));
                 RpoRandomCoin::new(rng_seed)
             };
-            let notes = build_p2id_notes(self.id, &valid_requests, &mut rng)?;
+                build_p2id_notes(self.id, &valid_requests, &mut rng)?
+            };
             let note_ids = notes.iter().map(Note::id).collect::<Vec<_>>();
             let tx_id = Box::pin(self.create_transaction(notes))
                 .await
                 .context("faucet failed to create transaction")?;
+            tracing::Span::current().record("tx_id", tx_id.to_string());
 
+            let send_resp_span = tracing::info_span!(target: COMPONENT, "faucet.mint.send_responses");
+            let _enter = send_resp_span.enter();
             for (sender, note_id) in response_senders.into_iter().zip(note_ids) {
                 // Ignore errors if the request was dropped.
                 let _ = sender.send(Ok(MintResponse { tx_id, note_id }));
             }
-            self.client.sync_state().await.context("faucet failed to sync state")?;
+            let sync_span = tracing::info_span!(target: COMPONENT, "faucet.mint.state_sync");
+            {
+                let _enter = sync_span.enter();
+                self.client.sync_state().await.context("faucet failed to sync state")?;
+            }
         }
 
         tracing::info!("Request stream closed, shutting down minter");
@@ -248,7 +291,10 @@ impl Faucet {
     /// Creates a transaction with the given notes, executes it, proves it, and submits using the
     /// local miden-client. This results in submitting the transaction to the node and updating the
     /// local db to track the created notes.
+    #[instrument(target = COMPONENT, name = "faucet.mint.create_tx", skip_all, err, fields(num_notes, tx_id))]
     async fn create_transaction(&mut self, notes: Vec<Note>) -> Result<TransactionId, ClientError> {
+        let span = tracing::Span::current();
+        span.record("num_notes", notes.len() as u64);
         // Build the transaction
         let expected_output_recipients = notes.iter().map(Note::recipient).cloned().collect();
         let n = notes.len() as u64;
@@ -273,20 +319,33 @@ impl Faucet {
             .build()?;
 
         // Execute the transaction
-        let tx_result =
-            Box::pin(self.client.new_transaction(self.id.account_id, tx_request)).await?;
+        let exec_span = tracing::info_span!(target: COMPONENT, "faucet.mint.execute");
+        let tx_result = {
+            let _enter = exec_span.enter();
+            Box::pin(self.client.new_transaction(self.id.account_id, tx_request)).await?
+        };
         let tx_id = tx_result.executed_transaction().id();
+        tracing::Span::current().record("tx_id", tx_id.to_string());
 
         // Prove and submit the transaction
-        let prover_failed = Box::pin(
-            self.client
-                .submit_transaction_with_prover(tx_result.clone(), self.tx_prover.clone()),
-        )
-        .await
-        .is_err();
+        let prove_remote_span = tracing::info_span!(target: COMPONENT, "faucet.mint.prove_remote");
+        let prover_failed = {
+            let _enter = prove_remote_span.enter();
+            Box::pin(
+                self.client
+                    .submit_transaction_with_prover(tx_result.clone(), self.tx_prover.clone()),
+            )
+            .await
+            .is_err()
+        };
         if prover_failed {
             warn!("Failed to prove transaction with remote prover, falling back to local prover");
-            Box::pin(self.client.submit_transaction(tx_result)).await?;
+            let submit_local_span =
+                tracing::info_span!(target: COMPONENT, "faucet.mint.prove_local_and_submit");
+            {
+                let _enter = submit_local_span.enter();
+                Box::pin(self.client.submit_transaction(tx_result)).await?;
+            }
         }
 
         Ok(tx_id)


### PR DESCRIPTION
Add end-to-end tracing spans for the mint lifecycle and server request paths to improve observability and debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-04ff8774-5259-46f5-b324-d33057bde19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04ff8774-5259-46f5-b324-d33057bde19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

