### PR TITLE
feat: sync state before creating the minting transaction

### DIFF
--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -5,7 +5,12 @@ use std::time::Duration;
 use anyhow::Context;
 use miden_client::account::component::{BasicFungibleFaucet, FungibleFaucetExt};
 use miden_client::account::{
-    AccountFile, AccountId, AccountIdAddress, Address, AddressInterface, NetworkId,
+    AccountFile,
+    AccountId,
+    AccountIdAddress,
+    Address,
+    AddressInterface,
+    NetworkId,
 };
 use miden_client::asset::FungibleAsset;
 use miden_client::builder::ClientBuilder;
@@ -14,7 +19,10 @@ use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{Note, NoteError, NoteId, create_p2id_note};
 use miden_client::rpc::Endpoint;
 use miden_client::transaction::{
-    LocalTransactionProver, TransactionId, TransactionProver, TransactionRequestBuilder,
+    LocalTransactionProver,
+    TransactionId,
+    TransactionProver,
+    TransactionRequestBuilder,
     TransactionScript,
 };
 use miden_client::utils::{Deserializable, RwLock};
@@ -202,8 +210,9 @@ impl Faucet {
         &mut self,
         requests: impl IntoIterator<Item = (MintRequest, MintResponseSender)>,
     ) -> anyhow::Result<()> {
-        // We sync before creating the transaction to ensure the state is up to date. If the previous
-        // transaction somehow failed to be included in the block, our state would be out of sync.
+        // We sync before creating the transaction to ensure the state is up to date. If the
+        // previous transaction somehow failed to be included in the block, our state would
+        // be out of sync.
         self.client
             .sync_state()
             .instrument(info_span!(target: COMPONENT, "faucet.mint.sync_state"))


### PR DESCRIPTION
As discussed offlined with @igamigo:

The testnet faucet started failing due to a pair of transactions not being submitted correctly to the node (still unknown why). This caused an out of sync state, where all subsequent transactions failed to submit to the node due to having a different account commitment.

This PR changes to sync the state before creating the mint transaction, so we ensure that the state is synced.