### PR TITLE
feat: use sync component

### DIFF
--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -209,7 +209,7 @@ impl Faucet {
             .sync_state(
                 current_partial_mmr,
                 accounts,
-                note_tags.clone(),
+                note_tags,
                 input_notes,
                 expected_output_notes,
                 uncommitted_transactions,

--- a/crates/faucet/src/note_screener.rs
+++ b/crates/faucet/src/note_screener.rs
@@ -1,5 +1,5 @@
-//! Implements a custom note screener that only marks notes as relevant if they are tagged. It
-//! discards all other notes.
+//! Implements a custom note screener that only marks notes as relevant if they are tracked output
+//! notes. It discards all other notes.
 use std::sync::Arc;
 
 use miden_client::rpc::domain::note::CommittedNote;


### PR DESCRIPTION
This PR uses the client's `SyncState` component to make the syncing more custom for the faucet use case.

In particular:
- no note tags are sent on the sync request. This avoids matching with unnecessary blocks due to the prefixes collisions.
- only sync expected output notes instead of unconsumed. This means we don't sync notes that already were marked as commited. Otherwise they would be synced to check for consumption, but we don't care.