### PR TITLE
fix: publish book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -57,8 +57,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         uses: actions/upload-pages-artifact@v3
         with:
-          # We specify multiple [output] sections in our book.toml which causes mdbook to create separate folders for each. This moves the generated `html` into its own `html` subdirectory.
-          path: ./docs/book/html
+          path: ./docs/book
 
   # Deployment job only runs on push to next.
   deploy:


### PR DESCRIPTION
In https://github.com/0xMiden/miden-faucet/pull/169 the mdbook-linkcheck was removed and that broke the publish-book workflow. This PR attempts to fix it.

In https://github.com/0xMiden/miden-faucet/pull/169 the `[output.linkcheck]` section was removed so now there is only one html output, that is placed directly in `docs/book`. This PR udpates the path used on the workflow.