### PR TITLE
fix: add store reference to sync process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.2 (2026-04-21)
+
+- Fixed faucet state sync to request storage map details for tracked public accounts ([#241](https://github.com/0xMiden/faucet/pull/241)).
+
 ## 0.14.1 (2026-04-16)
 
 - Updated miden-client dependency to v0.14.3 ([#239](https://github.com/0xMiden/faucet/pull/239)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet-client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet-lib"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "miden-pow-rate-limiter"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-faucet"
 rust-version = "1.93"
-version      = "0.14.1"
+version      = "0.14.2"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -16,13 +16,8 @@ use miden_client::rpc::{Endpoint, GrpcClient};
 use miden_client::store::{NoteFilter, TransactionFilter};
 use miden_client::sync::{StateSync, StateSyncInput, SyncSummary};
 use miden_client::transaction::{
-    LocalTransactionProver,
-    TransactionId,
-    TransactionProver,
-    TransactionRequest,
-    TransactionRequestBuilder,
-    TransactionRequestError,
-    TransactionScript,
+    LocalTransactionProver, TransactionId, TransactionProver, TransactionRequest,
+    TransactionRequestBuilder, TransactionRequestError, TransactionScript,
 };
 use miden_client::utils::Deserializable;
 use miden_client::{Client, ClientError, Felt, RemoteTransactionProver, Word};
@@ -125,8 +120,12 @@ impl Faucet {
         let note_screener = NoteScreener::new(sqlite_store.clone());
         let grpc_client =
             Arc::new(GrpcClient::new(&config.node_endpoint, config.timeout.as_millis() as u64));
-        let state_sync_component =
-            StateSync::new(grpc_client.clone(), None, Arc::new(note_screener), None);
+        let state_sync_component = StateSync::new(
+            grpc_client.clone(),
+            Some(sqlite_store.clone()),
+            Arc::new(note_screener),
+            None,
+        );
         Self::sync_state(account.id(), &mut client, &state_sync_component).await?;
 
         let add_result = client.add_account(&account, false).await;
@@ -155,10 +154,11 @@ impl Faucet {
     #[instrument(target = COMPONENT, name = "faucet.load", fields(account_id), skip_all, err)]
     pub async fn load(config: &FaucetConfig) -> anyhow::Result<Self> {
         let span = tracing::Span::current();
+        let sqlite_store = Arc::new(SqliteStore::new(config.store_path.clone()).await?);
         let mut client = ClientBuilder::new()
             .grpc_client(&config.node_endpoint, Some(config.timeout.as_millis() as u64))
             .filesystem_keystore(KEYSTORE_PATH)?
-            .store(Arc::new(SqliteStore::new(config.store_path.clone()).await?))
+            .store(sqlite_store.clone())
             .build()
             .await
             .context("failed to build client")?;
@@ -188,11 +188,11 @@ impl Faucet {
 
         let script = TransactionScript::read_from_bytes(TX_SCRIPT)?;
 
-        let note_screener =
-            NoteScreener::new(Arc::new(SqliteStore::new(config.store_path.clone()).await?));
+        let note_screener = NoteScreener::new(sqlite_store.clone());
         let grpc_client =
             Arc::new(GrpcClient::new(&config.node_endpoint, config.timeout.as_millis() as u64));
-        let state_sync_component = StateSync::new(grpc_client, None, Arc::new(note_screener), None);
+        let state_sync_component =
+            StateSync::new(grpc_client, Some(sqlite_store.clone()), Arc::new(note_screener), None);
 
         Ok(Self {
             id,
@@ -640,7 +640,7 @@ mod tests {
             client,
             state_sync_component: StateSync::new(
                 mock_rpc,
-                None,
+                Some(store.clone()),
                 Arc::new(NoteScreener::new(store.clone())),
                 None,
             ),

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -16,8 +16,13 @@ use miden_client::rpc::{Endpoint, GrpcClient};
 use miden_client::store::{NoteFilter, TransactionFilter};
 use miden_client::sync::{StateSync, StateSyncInput, SyncSummary};
 use miden_client::transaction::{
-    LocalTransactionProver, TransactionId, TransactionProver, TransactionRequest,
-    TransactionRequestBuilder, TransactionRequestError, TransactionScript,
+    LocalTransactionProver,
+    TransactionId,
+    TransactionProver,
+    TransactionRequest,
+    TransactionRequestBuilder,
+    TransactionRequestError,
+    TransactionScript,
 };
 use miden_client::utils::Deserializable;
 use miden_client::{Client, ClientError, Felt, RemoteTransactionProver, Word};


### PR DESCRIPTION
The issue is that the faucet was constructing `StateSync` without giving it the local store. In `miden-client 0.14.3`, that store is needed for public account syncing (not for anything note or transaction related): the client reads the locally tracked account storage to know which map slots to request from the node. Without it, the client asks the node for account details but does not request any storage map details. The node response is then internally consistent from the node’s perspective: it includes the account storage header, which says `allowed_policy_proc_roots` is a map, but `map_details` is empty because the client did not ask for that map.

Devnet likely did not hit this because it was on a different client path/version (previous client version did not use to have this), or because the faucet account did not enter the specific out-of-sync state that triggers public account detail parsing. Older client versions fetched full public accounts differently and did not rely on `StateSync`’s optional store in this same way.

On the client side we will need to improve this as this is not ideal (at the very least it should be better signaled; but also this should not be 100% necessary) - will create a separate issue for this.