### PR TITLE
 feat: add action to upload pre-compiled artifacts

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,3 +30,53 @@ jobs:
         run: cargo publish --workspace
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Upload the miden-faucet-client CLI as an artifact on the Github release.
+  # This is used by midenup to speed installs up.
+  upload-artifacts:
+    name: upload pre-built miden-faucet-client executable artifacts
+    if: ${{ github.repository_owner == '0xMiden' }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        target: [aarch64-apple-darwin, x86_64-unknown-linux-gnu]
+        exclude:
+          - os: macos-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+      - name: Install Rust
+        run: |
+          rustup update --no-self-update
+          rustc --version
+      - name: Add target
+        run: |
+          rustup target add ${{ matrix.target }}
+      - name: Build miden-faucet-client
+        run: |
+          BUILD_TARGET=${{ matrix.target }} make build-artifact
+      - name: Prepare artifact
+        run: |
+          mv target/${{ matrix.target }}/release/miden-faucet-client miden-faucet-client-${{ matrix.target }}
+      - name: Attest miden-faucet-client
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: miden-faucet-client-${{ matrix.target }}
+      - name: Upload
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          gh release upload ${RELEASE_TAG} miden-faucet-client-${{ matrix.target }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -65,7 +65,7 @@ jobs:
           rustup target add ${{ matrix.target }}
       - name: Build miden-faucet-client
         run: |
-          BUILD_TARGET=${{ matrix.target }} make build-artifact
+          BUILD_TARGET=${{ matrix.target }} make build-faucet-client
       - name: Prepare artifact
         run: |
           mv target/${{ matrix.target }}/release/miden-faucet-client miden-faucet-client-${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 build: ## By default we should build in release mode
 	cargo build --release
 
-.PHONY: build-artifact
-build-artifact: ## Build triple-specific binaries
+.PHONY: build-faucet-client
+build-faucet-client: ## Build triple-specific miden-faucet-client binary
 	cargo build --package miden-faucet-client --target $(BUILD_TARGET) --release
 
 # -- linting --------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,19 @@ help:
 
 # -- variables ------------------------------------------------------------------------------------
 
+# The build target defaults to rust's host.
+BUILD_TARGET ?= $(shell rustc -vV | grep host | awk '{print $$2}')
 WARNINGS=RUSTDOCFLAGS="-D warnings"
+
+# -- building -------------------------------------------------------------------------------------
+
+.PHONY: build
+build: ## By default we should build in release mode
+	cargo build --release
+
+.PHONY: build-artifact
+build-artifact: ## Build triple-specific binaries
+	cargo build --package miden-faucet-client --target $(BUILD_TARGET) --release
 
 # -- linting --------------------------------------------------------------------------------------
 
@@ -18,10 +30,6 @@ clippy: ## Runs Clippy with configs
 .PHONY: fix
 fix: ## Runs Fix with configs
 	cargo fix --allow-staged --allow-dirty --all-targets --all-features --workspace
-
-.PHONY: build
-build: ## By default we should build in release mode
-	cargo build --release
 
 .PHONY: format
 format: ## Runs Format using nightly toolchain

--- a/bin/faucet/src/frontend.rs
+++ b/bin/faucet/src/frontend.rs
@@ -58,7 +58,7 @@ pub async fn get_index_html() -> Html<&'static str> {
 pub async fn get_miden_client_web_wasm(request: Request) -> Response {
     const WASM_BYTES: &[u8] = include_bytes!(concat!(
         env!("OUT_DIR"),
-        "/frontend/node_modules/@miden-sdk/miden-sdk/dist/assets/miden_client_web.wasm"
+        "/frontend/node_modules/@miden-sdk/miden-sdk/dist/st/assets/miden_client_web.wasm"
     ));
 
     let etag = compute_etag(WASM_BYTES);


### PR DESCRIPTION
Closes https://github.com/0xMiden/midenup/issues/177?issue=0xMiden%7Cmidenup%7C205
Closes https://github.com/0xMiden/faucet/issues/247


This PR is on the same line as https://github.com/0xMiden/miden-client/pull/1936.

Note: I added a new directive entirely in order to not mess up with cargo's default `target/release` file placement, like it was the case with https://github.com/0xMiden/miden-client/pull/1962